### PR TITLE
[v2] feat: add default state support to form components

### DIFF
--- a/src/Forms/Components/StateFusionRadio.php
+++ b/src/Forms/Components/StateFusionRadio.php
@@ -14,6 +14,7 @@ class StateFusionRadio extends Radio implements HasStateAttributesContract
     {
         parent::setUp();
         $this->options(fn ($model) => (new $model)->getCasts()[$this->getAttribute()]::getStatesLabel($model));
+        $this->default(fn ($model) => $model::getDefaultStateFor($this->getAttribute()));
         $this->descriptions(fn ($model) => (new $model)->getCasts()[$this->getAttribute()]::getStatesDescription($model));
     }
 }

--- a/src/Forms/Components/StateFusionSelect.php
+++ b/src/Forms/Components/StateFusionSelect.php
@@ -14,5 +14,6 @@ class StateFusionSelect extends Select implements HasStateAttributesContract
     {
         parent::setUp();
         $this->options(fn ($model) => (new $model)->getCasts()[$this->getAttribute()]::getStatesLabel($model));
+        $this->default(fn ($model) => $model::getDefaultStateFor($this->getAttribute()));
     }
 }

--- a/src/Forms/Components/StateFusionToggleButtons.php
+++ b/src/Forms/Components/StateFusionToggleButtons.php
@@ -14,6 +14,7 @@ class StateFusionToggleButtons extends ToggleButtons implements HasStateAttribut
     {
         parent::setUp();
         $this->options(fn ($model) => (new $model)->getCasts()[$this->getAttribute()]::getStatesLabel($model));
+        $this->default(fn ($model) => $model::getDefaultStateFor($this->getAttribute()));
         $this->icons(fn ($model) => (new $model)->getCasts()[$this->getAttribute()]::getStatesIcon($model));
         $this->colors(fn ($model) => (new $model)->getCasts()[$this->getAttribute()]::getStatesColor($model));
     }


### PR DESCRIPTION
## Summary
- Added default state initialization to all StateFusion form components (Radio, Select, ToggleButtons)
- Form components now automatically use the model's default state when creating new records
- Ensures consistent state initialization across all form component types

## Changes
- Updated `StateFusionRadio` to call `getDefaultStateFor()` method
- Updated `StateFusionSelect` to call `getDefaultStateFor()` method  
- Updated `StateFusionToggleButtons` to call `getDefaultStateFor()` method

## Test Plan
- [ ] Verify form components display default state on create forms
- [ ] Test with models that have custom default states defined
- [ ] Ensure existing records are not affected (default only applies to new records)
- [ ] Verify compatibility with all three component types

## Related
Part of the feature/default-states branch which adds comprehensive default state support across the package.